### PR TITLE
Tests for default argument of nth

### DIFF
--- a/test/clojure/core_test/nth.cljc
+++ b/test/clojure/core_test/nth.cljc
@@ -16,4 +16,9 @@
     (is (thrown? #?(:cljs :default, :clj Exception) (nth [0 1 2] -1)))
     (is (thrown? #?(:cljs :default, :clj Exception) (nth [0 1 2] 10)))
     (is (thrown? #?(:cljs :default, :clj Exception) (nth [0 1 2] nil)))
-    (is (thrown? #?(:cljs :default, :clj Exception) (nth nil nil)))))
+    (is (thrown? #?(:cljs :default, :clj Exception) (nth nil nil)))
+
+    ;; `nth` accepts a default argument
+    (is (= :default (nth nil 0 :default)))
+    (is (= :default (nth [0] 1 :default)))
+    (is (= :default (nth [0 1] 2 :default)))))

--- a/test/clojure/core_test/nth.cljc
+++ b/test/clojure/core_test/nth.cljc
@@ -21,4 +21,5 @@
     ;; `nth` accepts a default argument
     (is (= :default (nth nil 0 :default)))
     (is (= :default (nth [0] 1 :default)))
-    (is (= :default (nth [0 1] 2 :default)))))
+    (is (= :default (nth [0 1] 2 :default)))
+    (is (= :default (nth [0 1] -1 :default)))))


### PR DESCRIPTION
@frenchy64 tests related to https://github.com/jank-lang/jank/pull/294

```
± |nth-default-tests ✓| → clj --version
Clojure CLI version 1.11.3.1463

± |nth-default-tests ✓| → lein test clojure.core-test.nth
OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.

lein test clojure.core-test.nth

Ran 1 tests containing 12 assertions.
0 failures, 0 errors.
```
