### PR TITLE
Make template smarter for clojure core

### DIFF
--- a/templates/test-template.cljc
+++ b/templates/test-template.cljc
@@ -1,7 +1,7 @@
 (ns {{base-ns}}-test.{{ns-suffix}}
   (:require {% if not base-ns = "clojure.core" %}{{base-ns}}
             {% endif %}[clojure.test :as t :refer [deftest testing is are]]
-            [clojure.core-test.portability #?(:cljs :refer-macros :default :refer)  [when-var-exists]]))
+            [clojure.core-test.portability #?(:cljs :refer-macros :default :refer) [when-var-exists]]))
 
 (when-var-exists {% if not base-ns = "clojure.core" %}{{base-ns}}/{% endif %}{{sym-name}}
   (deftest test-{{sym-name}}


### PR DESCRIPTION
This fixes redundant requiring of `clojure.core` and qualifying of vars `v` in `clojure.core` as `clojure.core/v`

Clojure.core template now
```clj
(ns clojure.core-test.baz
  (:require [clojure.test :as t :refer [deftest testing is are]]
            [clojure.core-test.portability #?(:cljs :refer-macros :default :refer) [when-var-exists]]))

(when-var-exists baz
  (deftest test-baz
    ;; `testing` sections are optional, depending on how you want to
    ;; structure your tests. If you have a lot of tests and they group
    ;; together in subgroups, then use `testing`. The `testing` form
    ;; can also be a nice way to group tests that only apply to a
    ;; subset of Clojure implementations. These can then be guarded by
    ;; reader conditionals.
    (testing "section name"
      (is (= 1 0)))))
```

And non clojure.core sections should be unchanged
```clj
(ns clojure.string-test.bat
  (:require clojure.string
            [clojure.test :as t :refer [deftest testing is are]]
            [clojure.core-test.portability #?(:cljs :refer-macros :default :refer) [when-var-exists]]))

(when-var-exists clojure.string/bat
  (deftest test-bat
    ;; `testing` sections are optional, depending on how you want to
    ;; structure your tests. If you have a lot of tests and they group
    ;; together in subgroups, then use `testing`. The `testing` form
    ;; can also be a nice way to group tests that only apply to a
    ;; subset of Clojure implementations. These can then be guarded by
    ;; reader conditionals.
    (testing "section name"
      (is (= 1 0)))))
```