### PR TITLE
test `merge`

### DIFF
--- a/test/clojure/core_test/merge.cljc
+++ b/test/clojure/core_test/merge.cljc
@@ -31,6 +31,14 @@
         (is (= {:x 1 :y 10 :z 100} (merge {:x 1 :y 5555}
                                           {:y 10 :z 100}))))
 
+      (testing "nested maps are replaced, not 'deep-merged'"
+        (is (= {:ceo {:name "Alice"},
+                :cto {:name "Brenda"}}
+               (merge {:ceo {:salary 1000000}} ; salary values are overwritten
+                      {:cto {:salary  500000}}
+                      {:ceo {:name "Alice"}}
+                      {:cto {:name "Brenda"}}))))
+
       (testing "map entries are accepted in position 2+, per `conj`"
         (is (= {:a "a", :b "b"} (merge {:a nil}
                                        (first {:a "a"})


### PR DESCRIPTION
Closes #360.

Because `merge` has a large surface area of somewhat-forgiving `conj`-driven undefined behavior, I chose not to test e.g. `(merge '(1 2 3) 1)` very closely. See last `testing` form; open to discussion.