### PR TITLE
Fix bad `:default` min value

### DIFF
--- a/test/clojure/core_test/number_range.cljc
+++ b/test/clojure/core_test/number_range.cljc
@@ -10,7 +10,7 @@
 (def ^:const min-int #?(:clj Long/MIN_VALUE
                         :cljr Int64/MinValue
                         :cljs js/Number.MIN_SAFE_INTEGER
-                        :default 0x8000000000000000))
+                        :default -0x8000000000000000))
 
 (def ^:const all-ones-int #?(:cljs 0xFFFFFFFF
                              :default -1))


### PR DESCRIPTION
This test was failing for me in jank and I think this test value is incorrect.

```clojure
% clj
Clojure 1.12.2
user=> Long/MIN_VALUE
-9223372036854775808
user=> -0x8000000000000000
-9223372036854775808
```