### PR TITLE
Prep `double` for `jank`

### DIFF
--- a/test/clojure/core_test/double.cljc
+++ b/test/clojure/core_test/double.cljc
@@ -23,6 +23,7 @@
        ;; In cljs, `double` is just returns the argument unchanged (dummy fn)
        [(is (= "0" (double "0")))
         (is (= :0 (double :0)))]
+       :jank []
 	   :cljr
        [(is (= 0.0 (double "0")))
         (is (thrown? Exception (double :0)))]


### PR DESCRIPTION
Created for the [port](https://github.com/jank-lang/jank/pull/583) in `jank`.