### PR TITLE
Test parse-uuid tolerance to non-standard forms

### DIFF
--- a/test/clojure/core_test/parse_uuid.cljc
+++ b/test/clojure/core_test/parse_uuid.cljc
@@ -16,6 +16,11 @@
       (when-var-exists clojure.core/instance?
         #?(:clj  (is (instance? java.util.UUID (parse-uuid "b6883c0a-0342-4007-9966-bc2dfa6b109e"))))
         #?(:cljs (is (instance? cljs.core.UUID (parse-uuid "b6883c0a-0342-4007-9966-bc2dfa6b109e"))))))
+    (testing "tolerance to non-standard forms"
+      (are [expected s] (= #?(:clj expected :default nil) (parse-uuid s)) ; clj is permissive, others are strict
+                        #uuid "00000000-0000-0000-0000-000000000000" "0-0-0-0-0"
+                        #uuid "00000012-0034-0056-0078-000000000009" "12-34-56-78-9"
+                        #uuid "00000005-0004-0003-0002-009000000001" "5-4-3-DEADBEEF0002-9000000001"))
     (testing "exceptions"
       #?(:clj (are [x] (thrown? Exception (parse-uuid x))
                    {}


### PR DESCRIPTION
When testing `uuid?`, noticed some differences of behavior between platforms when parsing non-standard forms of  UUIDs:

- ClojureScript and Clojure CLR are strict
- Clojure on JVM is quite permissive (because Java's `UUID.fromString` is permissive, see e.g. [JDK-8216407](https://bugs.openjdk.org/browse/JDK-8216407), [JDK-8159339](https://bugs.openjdk.org/browse/JDK-8159339)).

This PR adds cases to capture these differences.