### PR TITLE
Updates template to sort symbols in `:refer` clauses

### DIFF
--- a/templates/test-template.cljc
+++ b/templates/test-template.cljc
@@ -1,7 +1,7 @@
 (ns {{base-ns}}-test.{{ns-suffix}}
-  (:require {% if not base-ns = "clojure.core" %}{{base-ns}}
-            {% endif %}[clojure.test :as t :refer [deftest testing is are]]
-            [clojure.core-test.portability #?(:cljs :refer-macros :default :refer) [when-var-exists]]))
+    (:require {% if not base-ns = "clojure.core" %}{{base-ns}}
+              {% endif %}[clojure.test :as t :refer [are deftest is testing]]
+              [clojure.core-test.portability #?(:cljs :refer-macros :default :refer) [when-var-exists]]))
 
 (when-var-exists {% if not base-ns = "clojure.core" %}{{base-ns}}/{% endif %}{{sym-name}}
   (deftest test-{{sym-name}}


### PR DESCRIPTION
I noticed that @E-A-Griffin did a cleanup pass and was sorting the symbols in the `:refer` clauses of test namespaces. In order to promote future good hygiene, we should update the template to do what we prefer.