### PR TITLE
Standardize README

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The test file will look like the following:
 
 ```clojure
 (ns clojure.core-test.foo
-  (:require [clojure.test :as t :refer [deftest testing is are]]
+  (:require [clojure.test :as t :refer [are deftest is testing]]
             [clojure.core-test.portability #?(:cljs :refer-macros :default :refer) [when-var-exists]]))
 
 (when-var-exists foo


### PR DESCRIPTION
The `$` CLI prompt symbol is used inconsistently in the README. This standardizes it's usage to only be used for example CLI that involves `stdout`/`stderr` output where it can disambiguate commands being called from output being returned (otherwise not having it is nice because GitHub's UI allows you to copy commands for pasting into a terminal which will fail if you paste something starting with `$`)