### PR TITLE
Run each implementation's tests in separate Github Actions steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,6 @@ jobs:
       - name: Run Clojure tests
         run: lein test
 
-      - name: Run babashka tests
-        run: bb test-bb
-
   test-cljs:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
As I was working on #840 I realized that it isn't terribly easy to know when my changes might have affected other implementations, so I was hoping to have a feedback loop with CI. I split up each implementation into a separate Github Action step so they could all run in parallel and report back on the PR as a check. It's a bit duplicative right now because I just copied and pasted the different steps. There are ways to reduce that duplication, but I decided to err on the side of simplicity rather than attempting to over-engineer the YAML.

I had a mind to add some additional `bb` tasks in another PR to make it easier to run all of the test suites locally as well, so do let me know if that might be worth doing. The trick there is that I use a Mac so I'm sure I wouldn't be able to configure the steps for setting up various different Clojure implementations across multiple different OSes.

Just to note: this is just a suggestion to help improve the feedback loop for folks submitting, so let me know if this is actually not useful or preferred. Happy to close and continue with what was there if it was set up as such for a reason. Thanks!

