### PR TITLE
Update Babashka tasks

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -40,14 +40,4 @@
                    (run 'test-lpy))}
   new-test {:doc "Creates new test for the Clojure symbols named by <args>. Unqualified symbols assume clojure.core"
             :requires ([new-test])
-            :task (new-test/new-test *command-line-args*)}
-  #_nrepl #_{:doc "Starts an nrepl server on port 1339 using an .nrepl-port file"
-             :requires ([babashka.fs :as fs]
-                        [babashka.nrepl.server :as srv])
-             :task (do (srv/start-server! {:host "localhost"
-                                           :port 1339})
-                    (spit ".nrepl-port" "1339")
-                    (-> (Runtime/getRuntime)
-                     (.addShutdownHook
-                      (Thread. (fn [] (fs/delete ".nrepl-port")))))
-                    (deref (promise)))}}}
+            :task (new-test/new-test *command-line-args*)}}}

--- a/bb.edn
+++ b/bb.edn
@@ -9,11 +9,11 @@
           (println stars)
           (println "*" message spaces "*")
           (println stars)))
-  test-jvm {:doc "Runs JVM tests"
+  test-jvm {:doc "Runs tests in JVM"
             :task (do
                    (banner "Running JVM Tests")
                    (shell "lein test"))}
-  test-bb {:doc "Runs bb tests"
+  test-bb {:doc "Runs tests in Babashka"
            :extra-deps {io.github.cognitect-labs/test-runner
                         {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
            :extra-paths ["test"]
@@ -21,11 +21,11 @@
                   (banner "Running Babashka Tests")
                   (exec 'cognitect.test-runner.api/test))
            :exec-args {:patterns [".*"]}}
-  test-cljs {:doc "Runs CLJS tests"
+  test-cljs {:doc "Runs tests in ClojureScript"
              :task (do
                     (banner "Running CLJS Tests")
                     (shell "npx shadow-cljs compile test"))}
-  test-lpy {:doc  "Run Basilisp tests"
+  test-lpy {:doc  "Run tests in Basilisp"
             :task (do
                    (banner "Running Basilisp Tests")
                    (shell
@@ -38,6 +38,34 @@
                    (run 'test-cljs)
                    (run 'test-bb)
                    (run 'test-lpy))}
+  test {:doc "Runs tests in multiple named dialects: jvm, bb, cljs, or lpy"
+        :task (letfn [(help []
+                       (println "Usage: bb test <dialect1> [<dialect2>]...")
+                       (println "Where <dialect> is one of:")
+                       (println "  jvm     Runs tests in Clojure JVM")
+                       (println "  cljs    Runs tests in ClojureScript")
+                       (println "  bb      Runs tests in Babashka")
+                       (println "  lpy     Runs tests in Basilisp")
+                       (println "Tests are run in the order given."))]
+               (let [valid #{"jvm" "cljs" "bb" "lpy"}
+                     unknown (remove valid *command-line-args*)]
+                (cond
+                 (not (some? (seq *command-line-args*)))
+                 (do
+                  (help))
+
+                 (some? (seq unknown))
+                 (do
+                  (println "Unknown dialect name(s):" (clojure.string/join ", " unknown))
+                  (help))
+
+                 :else
+                 (doseq [dialect (seq *command-line-args*)]
+                  (case dialect
+                   "jvm" (run 'test-jvm)
+                   "cljs" (run 'test-cljs)
+                   "bb" (run 'test-bb)
+                   "lpy" (run 'test-lpy))))))}
   new-test {:doc "Creates new test for the Clojure symbols named by <args>. Unqualified symbols assume clojure.core"
             :requires ([new-test])
             :task (new-test/new-test *command-line-args*)}}}

--- a/bb.edn
+++ b/bb.edn
@@ -46,8 +46,9 @@
                        (println "  cljs    Runs tests in ClojureScript")
                        (println "  bb      Runs tests in Babashka")
                        (println "  lpy     Runs tests in Basilisp")
+                       (println "  all     Runs tests in all supported dialects")
                        (println "Tests are run in the order given."))]
-               (let [valid #{"jvm" "cljs" "bb" "lpy"}
+               (let [valid #{"jvm" "cljs" "bb" "lpy" "all"}
                      unknown (remove valid *command-line-args*)]
                 (cond
                  (not (some? (seq *command-line-args*)))
@@ -65,7 +66,8 @@
                    "jvm" (run 'test-jvm)
                    "cljs" (run 'test-cljs)
                    "bb" (run 'test-bb)
-                   "lpy" (run 'test-lpy))))))}
+                   "lpy" (run 'test-lpy)
+                   "all" (run 'test-all))))))}
   new-test {:doc "Creates new test for the Clojure symbols named by <args>. Unqualified symbols assume clojure.core"
             :requires ([new-test])
             :task (new-test/new-test *command-line-args*)}}}


### PR DESCRIPTION
Does three things:
1. Removes the `nrepl` Babashka task that was in bb.edn because nobody seems to know why it's there.
2. Adds a `bb test <dialect1> [<dialects>]...` task to allow the user to run tests against multiple dialects but perhaps not all.
3. Adds a `bb test all` task to run all tests against all dialects.