### PR TITLE
Fix "bb test all <dialect>" to just run tests once

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -60,14 +60,16 @@
                   (println "Unknown dialect name(s):" (clojure.string/join ", " unknown))
                   (help))
 
+                 (some? (seq (some #{"all"} *command-line-args*)))
+                 (run 'test-all)
+
                  :else
                  (doseq [dialect (seq *command-line-args*)]
                   (case dialect
                    "jvm" (run 'test-jvm)
                    "cljs" (run 'test-cljs)
                    "bb" (run 'test-bb)
-                   "lpy" (run 'test-lpy)
-                   "all" (run 'test-all))))))}
+                   "lpy" (run 'test-lpy))))))}
   new-test {:doc "Creates new test for the Clojure symbols named by <args>. Unqualified symbols assume clojure.core"
             :requires ([new-test])
             :task (new-test/new-test *command-line-args*)}}}


### PR DESCRIPTION
Previously, if you ran "bb test all jvm", for example, it would run the tests in all dialects and then run them again in Clojure JVM. Now, if "all" is given as a parameter, it only runs the tests once in all the dialects. In other words, once "all" is supplied, it treats all the other dialect options as redundant.