### PR TITLE
Switch Basilisp test suite to use only 2 CPUs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
   test-jvm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Prepare java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "21"
@@ -30,7 +30,7 @@ jobs:
           bb: latest
 
       - name: Cache clojure dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.m2/repository
@@ -46,10 +46,10 @@ jobs:
   test-cljs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Prepare java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "21"
@@ -62,7 +62,7 @@ jobs:
           bb: latest
 
       - name: Cache clojure dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.m2/repository
@@ -73,7 +73,7 @@ jobs:
           restore-keys: cljdeps-${{ env.CACHE_VERSION }}-
 
       - name: Prepare node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "23.x"
           check-latest: true
@@ -92,16 +92,16 @@ jobs:
   test-bb:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Prepare java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "21"
 
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@13.2
+        uses: DeLaGuardo/setup-clojure@13.6
         with:
           cli: 1.12.0.1530
           lein: 2.11.2
@@ -111,7 +111,7 @@ jobs:
         run: bash <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install) --dev-build --dir /tmp
 
       - name: Cache clojure dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.m2/repository
@@ -127,7 +127,7 @@ jobs:
   test-clr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Prepare dotnet
         uses: xt0rted/setup-dotnet@v1.5.0
@@ -143,9 +143,9 @@ jobs:
   test-basilisp:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           java-version: "21"
 
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@13.2
+        uses: DeLaGuardo/setup-clojure@13.6.0
         with:
           cli: 1.12.0.1530
           lein: 2.11.2
@@ -55,7 +55,7 @@ jobs:
           java-version: "21"
 
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@13.2
+        uses: DeLaGuardo/setup-clojure@13.6.0
         with:
           cli: 1.12.0.1530
           lein: 2.11.2
@@ -101,7 +101,7 @@ jobs:
           java-version: "21"
 
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@13.6
+        uses: DeLaGuardo/setup-clojure@13.6.0
         with:
           cli: 1.12.0.1530
           lein: 2.11.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,4 +161,4 @@ jobs:
           source .venv/bin/activate
           BASILISP_TEST_PATH="$(pwd)/test" \
             BASILISP_TEST_FILE_PATTERN='.*\.(lpy|cljc)' \
-            basilisp test -p test -- -n auto
+            basilisp test -p test -- -n 2

--- a/bb.edn
+++ b/bb.edn
@@ -31,7 +31,7 @@
                    (shell
                     {:extra-env {"BASILISP_TEST_PATH"         "./test"
                                  "BASILISP_TEST_FILE_PATTERN" ".*\\.(lpy|cljc)"}}
-                    "basilisp test -p test -- -n auto"))}
+                    "basilisp test -p test -- -n 2"))}
   test-all {:doc "Run tests under all dialects"
             :task (do
                    (run 'test-jvm)


### PR DESCRIPTION
`pytest-xdist`'s `auto` option can often be slower than setting a specific number of CPUs. I think standard Github Actions workers only have 2 vCPUs so this should end up actually being faster than using `auto`.

I also bumped the different Github Actions versions to use newer releases which use Node 24 to suppress some warnings during the runs.