### PR TITLE
Use Python 3.14 for CI runs; disable `pytest-xdist` for Basilisp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install pip and dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,4 +161,4 @@ jobs:
           source .venv/bin/activate
           BASILISP_TEST_PATH="$(pwd)/test" \
             BASILISP_TEST_FILE_PATTERN='.*\.(lpy|cljc)' \
-            basilisp test -p test -- -n 2
+            basilisp test -p test -- -n 0

--- a/bb.edn
+++ b/bb.edn
@@ -31,7 +31,7 @@
                    (shell
                     {:extra-env {"BASILISP_TEST_PATH"         "./test"
                                  "BASILISP_TEST_FILE_PATTERN" ".*\\.(lpy|cljc)"}}
-                    "basilisp test -p test -- -n 2"))}
+                    "basilisp test -p test -- -n 0"))}
   test-all {:doc "Run tests under all dialects"
             :task (do
                    (run 'test-jvm)


### PR DESCRIPTION
* Python 3.14 should be a bit faster for Basilisp CI runs, so switch that version and hopefully reap the benefits.
* Disabling `pytest-xdist` since it's actually slower than just running on one CPU.