### PR TITLE
Clean up `key` and `val` tests

### DIFF
--- a/test/clojure/core_test/key.cljc
+++ b/test/clojure/core_test/key.cljc
@@ -4,30 +4,23 @@
 
 (when-var-exists key
   (deftest test-key
-    (testing "`key` on map-entry-like things"
+    (testing "basic tests"
       (is (= nil (key (first {nil nil}))))
       (is (= :k (key (first {:k :v}))))
-      (is (contains? #{:k :one} (key (first {:k :v, :one :two}))))
-      ;; Note: the following may be built on shaky ground, per Rich:
-      ;; https://groups.google.com/g/clojure/c/FVcrbHJpCW4/m/Fh7NsX_Yb7sJ
-      (is (= 'k (key #?(:cljs    (cljs.core/MapEntry. 'k 'v nil)
-                        :lpy     (map-entry 'k 'v)
-                        :phel    (map-entry 'k 'v)
-                        :default (clojure.lang.MapEntry/create 'k 'v)))))
+      (is (= :k (key (first (hash-map :k :v)))))
       (when-var-exists sorted-map
-        (is (= :a (key (first (sorted-map :a :b))))))
-      (is (= :a (key (first (hash-map :a :b)))))
+        (is (= :k (key (first (sorted-map :k :v))))))
       (when-var-exists array-map
-        (is (= :a (key (first (array-map :a :b)))))))
+        (is (= :k (key (first (array-map :k :v)))))))
     (testing "`key` throws on lots of things"
       (are [arg] (p/thrown? (key arg))
-                 nil
-                 0
-                 '()
-                 '(1 2)
-                 {}
-                 {1 2}
-                 []
-                 [1 2]
-                 #{}
-                 #{1 2}))))
+        nil
+        0
+        '()
+        '(1 2)
+        {}
+        {1 2}
+        []
+        [1 2]                           ; might be dialect-specific
+        #{}
+        #{1 2}))))

--- a/test/clojure/core_test/val.cljc
+++ b/test/clojure/core_test/val.cljc
@@ -4,29 +4,23 @@
 
 (when-var-exists val
   (deftest test-val
-    (testing "`val` on map-entry-like things"
+    (testing "basic tests"
+      (is (nil? (val (first {nil nil}))))
       (is (= :v (val (first {:k :v}))))
-      (is (contains? #{:two :v} (val (first {:k :v, :one :two}))))
-      ;; Note: the following may be built on shaky ground, per Rich:
-      ;; https://groups.google.com/g/clojure/c/FVcrbHJpCW4/m/Fh7NsX_Yb7sJ
-      (is (= 'v (val #?(:cljs    (cljs.core/MapEntry. 'k 'v nil)
-                        :lpy     (map-entry 'k 'v)
-                        :phel    (map-entry 'k 'v)
-                        :default (clojure.lang.MapEntry/create 'k 'v)))))
-      (is (= :b (val (first (hash-map :a :b)))))
+      (is (= :v (val (first (hash-map :k :v)))))
       (when-var-exists sorted-map
-        (is (= :b (val (first (sorted-map :a :b))))))
+        (is (= :v (val (first (sorted-map :k :v))))))
       (when-var-exists array-map
-        (is (= :b (val (first (array-map :a :b)))))))
+        (is (= :v (val (first (array-map :k :v)))))))
     (testing "`val` throws on lots of things"
       (are [arg] (p/thrown? (val arg))
-                 nil
-                 0
-                 '()
-                 '(1 2)
-                 {}
-                 {1 2}
-                 []
-                 [1 2]
-                 #{}
-                 #{1 2}))))
+        nil
+        0
+        '()
+        '(1 2)
+        {}
+        {1 2}
+        []
+        [1 2]                           ; might be dialect-specific
+        #{}
+        #{1 2}))))


### PR DESCRIPTION
Cleans up some of the tests in `key` and `val`. Notably, removes tests that explicitly try to create a dialect-specific `MapEntry` object of some sort. This sort of testing isn't required. Since there is no `clojure.core` API to create a map entry, the best we can do is just use a sequence function on a map and test that `key` and `val` work on whatever is returned.

This also uses `:k` and `:v` consistently in all tests to make the tests easier to read.