### PR TITLE
chore(deps): bump phel-lang to ^0.38

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "phel-lang/phel-lang": "^0.37"
+        "phel-lang/phel-lang": "^0.38"
     },
     "scripts": {
         "test": "XDEBUG_MODE=off ./vendor/bin/phel test"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a715e87fd47198697005d49d2c3a63e4",
+    "content-hash": "3f53c92650283dcf04dddc2d93bd0dc5",
     "packages": [
         {
             "name": "amphp/amp",
@@ -242,16 +242,16 @@
         },
         {
             "name": "phel-lang/phel-lang",
-            "version": "v0.37.0",
+            "version": "v0.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phel-lang/phel-lang.git",
-                "reference": "091e9be0ff0f52ccfb4340e6776db1243ef96933"
+                "reference": "ecf3779e8c72e013b9c9751f4fa415d6b56d6c3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phel-lang/phel-lang/zipball/091e9be0ff0f52ccfb4340e6776db1243ef96933",
-                "reference": "091e9be0ff0f52ccfb4340e6776db1243ef96933",
+                "url": "https://api.github.com/repos/phel-lang/phel-lang/zipball/ecf3779e8c72e013b9c9751f4fa415d6b56d6c3b",
+                "reference": "ecf3779e8c72e013b9c9751f4fa415d6b56d6c3b",
                 "shasum": ""
             },
             "require": {
@@ -310,7 +310,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phel-lang/phel-lang/issues",
-                "source": "https://github.com/phel-lang/phel-lang/tree/v0.37.0"
+                "source": "https://github.com/phel-lang/phel-lang/tree/v0.38.0"
             },
             "funding": [
                 {
@@ -318,7 +318,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2026-05-12T13:13:01+00:00"
+            "time": "2026-05-16T18:05:12+00:00"
         },
         {
             "name": "psr/container",

--- a/doc/phel.md
+++ b/doc/phel.md
@@ -58,7 +58,7 @@ Format the test sources (uses `withFormatDirs` from `phel-config.php`):
 ```json
 {
     "require": {
-        "phel-lang/phel-lang": "^0.37"
+        "phel-lang/phel-lang": "^0.38"
     }
 }
 ```


### PR DESCRIPTION
## Summary

- Bump `phel-lang/phel-lang` from `^0.37` to `^0.38` in `composer.json` (and the example block in `doc/phel.md`).
- Refresh `composer.lock`.

## Why

Phel 0.38.0 ([release notes](https://github.com/phel-lang/phel-lang/releases/tag/v0.38.0)) ships a native `phel.core/lazy-seq?` predicate ([phel-lang/phel-lang#1992](https://github.com/phel-lang/phel-lang/pull/1992)). This unlocks a cleaner `:phel` branch for the upcoming portable `lazy-seq?` in `portability.cljc` (see #883) — letting that PR use:

```clojure
:phel (phel.core/lazy-seq? x)
```

instead of leaking `Phel\Lang\Collections\LazySeq\LazySeqInterface` into the shared test file.

Splitting the version bump out keeps #883 focused and isolates any 0.38 regression risk to a single small diff.
