### PR TITLE
chore(deps): bump phel-lang to ^0.39

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,40 +170,40 @@ jobs:
   #          BASILISP_TEST_FILE_PATTERN='.*\.(lpy|cljc)' \
   #          basilisp test -p test -- -n 0
 
-  #test-phel:
-  #  runs-on: ubuntu-latest
-  #  strategy:
-  #    fail-fast: false
-  #    matrix:
-  #      php: ['8.4', '8.5']
-  #  steps:
-  #    - uses: actions/checkout@v4
+  test-phel:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.4', '8.5']
+    steps:
+      - uses: actions/checkout@v4
 
-  #    - uses: shivammathur/setup-php@v2
-  #      with:
-  #        php-version: ${{ matrix.php }}
-  #        coverage: none
-  #        tools: composer
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: composer
 
-  #    - name: Cache Composer downloads
-  #      uses: actions/cache@v4
-  #      with:
-  #        path: ~/.composer/cache
-  #        key: composer-${{ matrix.php }}-${{ hashFiles('composer.lock') }}
-  #        restore-keys: |
-  #          composer-${{ matrix.php }}-
+      - name: Cache Composer downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: composer-${{ matrix.php }}-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            composer-${{ matrix.php }}-
 
-  #    - name: Cache Phel compiled artifacts
-  #      uses: actions/cache@v4
-  #      with:
-  #        path: .phel/cache
-  #        key: phel-cache-${{ matrix.php }}-${{ hashFiles('composer.lock', 'phel-config.php') }}-${{ hashFiles('test/**/*.cljc', 'test/**/*.phel') }}
-  #        restore-keys: |
-  #          phel-cache-${{ matrix.php }}-${{ hashFiles('composer.lock', 'phel-config.php') }}-
-  #          phel-cache-${{ matrix.php }}-
+      - name: Cache Phel compiled artifacts
+        uses: actions/cache@v4
+        with:
+          path: .phel/cache
+          key: phel-cache-${{ matrix.php }}-${{ hashFiles('composer.lock', 'phel-config.php') }}-${{ hashFiles('test/**/*.cljc', 'test/**/*.phel') }}
+          restore-keys: |
+            phel-cache-${{ matrix.php }}-${{ hashFiles('composer.lock', 'phel-config.php') }}-
+            phel-cache-${{ matrix.php }}-
 
-  #    - name: Install dependencies
-  #      run: composer install --no-interaction --no-ansi --no-progress
+      - name: Install dependencies
+        run: composer install --no-interaction --no-ansi --no-progress
 
-  #    - name: Run tests
-  #      run: composer test
+      - name: Run tests
+        run: composer test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,40 +170,40 @@ jobs:
   #          BASILISP_TEST_FILE_PATTERN='.*\.(lpy|cljc)' \
   #          basilisp test -p test -- -n 0
 
-  test-phel:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        php: ['8.4', '8.5']
-    steps:
-      - uses: actions/checkout@v4
+  #test-phel:
+  #  runs-on: ubuntu-latest
+  #  strategy:
+  #    fail-fast: false
+  #    matrix:
+  #      php: ['8.4', '8.5']
+  #  steps:
+  #    - uses: actions/checkout@v4
 
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          coverage: none
-          tools: composer
+  #    - uses: shivammathur/setup-php@v2
+  #      with:
+  #        php-version: ${{ matrix.php }}
+  #        coverage: none
+  #        tools: composer
 
-      - name: Cache Composer downloads
-        uses: actions/cache@v4
-        with:
-          path: ~/.composer/cache
-          key: composer-${{ matrix.php }}-${{ hashFiles('composer.lock') }}
-          restore-keys: |
-            composer-${{ matrix.php }}-
+  #    - name: Cache Composer downloads
+  #      uses: actions/cache@v4
+  #      with:
+  #        path: ~/.composer/cache
+  #        key: composer-${{ matrix.php }}-${{ hashFiles('composer.lock') }}
+  #        restore-keys: |
+  #          composer-${{ matrix.php }}-
 
-      - name: Cache Phel compiled artifacts
-        uses: actions/cache@v4
-        with:
-          path: .phel/cache
-          key: phel-cache-${{ matrix.php }}-${{ hashFiles('composer.lock', 'phel-config.php') }}-${{ hashFiles('test/**/*.cljc', 'test/**/*.phel') }}
-          restore-keys: |
-            phel-cache-${{ matrix.php }}-${{ hashFiles('composer.lock', 'phel-config.php') }}-
-            phel-cache-${{ matrix.php }}-
+  #    - name: Cache Phel compiled artifacts
+  #      uses: actions/cache@v4
+  #      with:
+  #        path: .phel/cache
+  #        key: phel-cache-${{ matrix.php }}-${{ hashFiles('composer.lock', 'phel-config.php') }}-${{ hashFiles('test/**/*.cljc', 'test/**/*.phel') }}
+  #        restore-keys: |
+  #          phel-cache-${{ matrix.php }}-${{ hashFiles('composer.lock', 'phel-config.php') }}-
+  #          phel-cache-${{ matrix.php }}-
 
-      - name: Install dependencies
-        run: composer install --no-interaction --no-ansi --no-progress
+  #    - name: Install dependencies
+  #      run: composer install --no-interaction --no-ansi --no-progress
 
-      - name: Run tests
-        run: composer test
+  #    - name: Run tests
+  #      run: composer test

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "phel-lang/phel-lang": "^0.38"
+        "phel-lang/phel-lang": "^0.39"
     },
     "scripts": {
         "test": "XDEBUG_MODE=off ./vendor/bin/phel test"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3f53c92650283dcf04dddc2d93bd0dc5",
+    "content-hash": "8528b44c559ca9101465f040ae1b2881",
     "packages": [
         {
             "name": "amphp/amp",
@@ -242,16 +242,16 @@
         },
         {
             "name": "phel-lang/phel-lang",
-            "version": "v0.38.0",
+            "version": "v0.39.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phel-lang/phel-lang.git",
-                "reference": "ecf3779e8c72e013b9c9751f4fa415d6b56d6c3b"
+                "reference": "5d89b55910cd5fad22e14a0a40f359948412e390"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phel-lang/phel-lang/zipball/ecf3779e8c72e013b9c9751f4fa415d6b56d6c3b",
-                "reference": "ecf3779e8c72e013b9c9751f4fa415d6b56d6c3b",
+                "url": "https://api.github.com/repos/phel-lang/phel-lang/zipball/5d89b55910cd5fad22e14a0a40f359948412e390",
+                "reference": "5d89b55910cd5fad22e14a0a40f359948412e390",
                 "shasum": ""
             },
             "require": {
@@ -310,7 +310,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phel-lang/phel-lang/issues",
-                "source": "https://github.com/phel-lang/phel-lang/tree/v0.38.0"
+                "source": "https://github.com/phel-lang/phel-lang/tree/v0.39.0"
             },
             "funding": [
                 {
@@ -318,7 +318,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2026-05-16T18:05:12+00:00"
+            "time": "2026-05-19T09:04:48+00:00"
         },
         {
             "name": "psr/container",
@@ -375,16 +375,16 @@
         },
         {
             "name": "revolt/event-loop",
-            "version": "v1.0.8",
+            "version": "v1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/revoltphp/event-loop.git",
-                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c"
+                "reference": "44061cf513e53c6200372fc935ac42271566295d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/b6fc06dce8e9b523c9946138fa5e62181934f91c",
-                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/44061cf513e53c6200372fc935ac42271566295d",
+                "reference": "44061cf513e53c6200372fc935ac42271566295d",
                 "shasum": ""
             },
             "require": {
@@ -394,7 +394,7 @@
                 "ext-json": "*",
                 "jetbrains/phpstorm-stubs": "^2019.3",
                 "phpunit/phpunit": "^9",
-                "psalm/phar": "^5.15"
+                "psalm/phar": "6.16.*"
             },
             "type": "library",
             "extra": {
@@ -441,9 +441,9 @@
             ],
             "support": {
                 "issues": "https://github.com/revoltphp/event-loop/issues",
-                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.8"
+                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.9"
             },
-            "time": "2025-08-27T21:33:23+00:00"
+            "time": "2026-05-16T17:55:38+00:00"
         },
         {
             "name": "symfony/console",

--- a/test/clojure/core_test/add_watch.cljc
+++ b/test/clojure/core_test/add_watch.cljc
@@ -21,7 +21,7 @@
                                                     :clj clojure.lang.ExceptionInfo
                                                     :cljr clojure.lang.ExceptionInfo
                                                     :lpy basilisp.lang.exception/ExceptionInfo
-                                                    :phel Phel.Lang.ExInfoException) e
+                                                    :phel Phel.Lang.ExceptionInfo) e
                                             (let [data (ex-data e)]
                                               (vswap! state conj data)))))]
                         (do-update a)


### PR DESCRIPTION
## Summary

Bump `phel-lang/phel-lang` to `^0.39` and align `add_watch.cljc` with upstream class rename. CI job for phel stays disabled (per [clojure-test-suite Slack policy, 2026-05-18](https://github.com/jank-lang/clojure-test-suite/issues/885)) until parity API lands.

- `composer.json`: `^0.38` → `^0.39`
- `composer.lock`: regenerated against v0.39.0
- `test/clojure/core_test/add_watch.cljc`: `:phel Phel.Lang.ExInfoException` → `:phel Phel.Lang.ExceptionInfo`

v0.39.0 ([release notes](https://github.com/phel-lang/phel-lang/releases/tag/v0.39.0)) ships:
- LazySeq `next`/`rest` aligned with Clojure semantics ([phel-lang#1997](https://github.com/phel-lang/phel-lang/pull/1997)) — fixes 3 assertions in `test/clojure/core_test/lazy_seq.cljc` where `(realized? (rest s))` was incorrectly reporting `true`.
- Class rename `Phel.Lang.ExInfoException` → `Phel.Lang.ExceptionInfo` ([phel-lang#2006](https://github.com/phel-lang/phel-lang/pull/2006)) to match `clojure.lang.ExceptionInfo`.