### PR TITLE
initial tests for clojure.core/merge-with

### DIFF
--- a/test/clojure/core_test/merge_with.cljc
+++ b/test/clojure/core_test/merge_with.cljc
@@ -1,0 +1,79 @@
+(ns clojure.core-test.merge-with
+  (:require [clojure.test :as t :refer [deftest is testing]]
+            [clojure.core-test.portability #?(:cljs :refer-macros :default :refer) [when-var-exists] :as p]))
+
+(defn second-arg [_a b] b)
+
+(when-var-exists
+ merge-with
+ (deftest test-merge-with
+   (testing "`merge-with`"
+
+     (testing "zero arg behavior"
+       ;; NOTE: clojurescript differs from the rest here, bug?
+       #?(:clj     (is (p/thrown? (merge-with)))
+          :cljs    (is (nil? (merge-with))) ; TODO how to suppress warning
+          :default (is (p/thrown? (merge-with)))))
+
+     (testing "`nil`ish behavior"
+       (is (nil? (merge-with second-arg nil)))
+       (is (nil? (merge-with second-arg nil nil nil)))
+       (is (= {} (merge-with second-arg {} nil)))
+       (is (= {} (merge-with second-arg nil {}))) ;; fails in basilisp => nil
+       (is (= {:a 1} (merge-with second-arg {:a 1} nil {})))
+       (is (= {:a 1} (merge-with second-arg {:a 1} {} nil))))
+
+     (testing "f is applied left-to-right across maps"
+       ;; str is non-commutative, so order reveals the fold direction
+       (is (= {:a "123"} (merge-with str {:a "1"} {:a "2"} {:a "3"}))))
+
+     (testing "falsey values still trigger f on collision"
+       (is (= {:a false} (merge-with second-arg {:a true} {:a false})))
+       (is (= {:a nil} (merge-with second-arg {:a true} {:a nil}))))
+
+     (testing "when f returns nil, the key is kept with a nil value"
+       (is (= {:a nil} (merge-with (constantly nil) {:a 1} {:a 2}))))
+
+     (testing "f is only called on the values of duplicate keys"
+       (let [called-with (atom [])
+             tracking-sum (fn [a b]
+                            (swap! called-with conj [a b])
+                            (+ a b))]
+         ;; f is never called, no conflicts
+         (merge-with tracking-sum {:a 1 :b 10} {:c 100})
+         (is (= [] @called-with))
+         ;; f only called for values of :b
+         (merge-with tracking-sum {:a 1 :b 10} {:c 100 :b 20})
+         (is (= [[10 20]] @called-with))))
+
+     (testing "non-map types"
+       #?(:clj    (is (thrown-with-msg? java.lang.ClassCastException
+                                        #".*cannot be cast to .*"
+                                        (merge-with second-arg {:a 1} [:a 2])))
+          :cljs    (is (p/thrown? (merge-with second-arg {:a 1} [:a 2])))
+          :default (is (p/thrown? (merge-with second-arg {:a 1} [:a 2]))))
+       #?(:clj    (is (thrown-with-msg? java.lang.IllegalArgumentException
+                                        #"^Don't know how to create ISeq from.*"
+                                        (merge-with second-arg {:a 1} 1)))
+          :cljs    (is (p/thrown? (merge-with second-arg {:a 1} 1)))
+          :default (is (p/thrown? (merge-with second-arg {:a 1} 1)))))
+
+     (testing "duplicate mappings are handled according to f"
+       (is (= {:a 2} (merge-with second-arg {:a 1} {:a 2})))
+       (is (= {:a 3} (merge-with + {:a 1} {:a 2})))
+       (let [val 2]
+         (is (= {:a 4} (merge-with + {:a val} {:a val})))) ; not fooled by identity
+       (is (= {:a 3 :b 1} (merge-with + {:a 1} {:b 1} nil {:a 2})))
+       (is (= {:a [1 2] :b 3} (merge-with (fn [a b] (if (vector? a)
+                                                      (conj a b)
+                                                      [a b]))
+                                          {:a 1} {:a 2} {:b 3}))))
+
+     (testing "nested maps are merged with `into`"
+       (is (= {:ceo {:salary 1000000, :name "Alice"},
+               :cto {:salary 500000, :name "Brenda"}}
+              (merge-with into
+                          {:ceo {:salary 1000000}}
+                          {:cto {:salary  500000}}
+                          {:ceo {:name "Alice"}}
+                          {:cto {:name "Brenda"}})))))))

--- a/test/clojure/core_test/merge_with.cljc
+++ b/test/clojure/core_test/merge_with.cljc
@@ -10,9 +10,8 @@
    (testing "`merge-with`"
 
      (testing "zero arg behavior"
-       #?(:clj     (is (p/thrown? (merge-with)))
-          :cljs    (is (nil? (merge-with))) ; TODO how to suppress warning
-          :default (is (p/thrown? (merge-with)))))
+       #?(:cljs    (is (nil? (merge-with)))
+          :clj     (is (p/thrown? (merge-with)))))
 
      (testing "`nil`ish behavior"
        (is (nil? (merge-with second-arg nil)))
@@ -46,15 +45,15 @@
          (is (= [[10 20]] @called-with))))
 
      (testing "non-map types"
-       #?(:clj    (is (thrown-with-msg? java.lang.ClassCastException
+       #?(:cljs    (is (p/thrown? (merge-with second-arg {:a 1} [:a 2])))
+          :clj    (is (thrown-with-msg? java.lang.ClassCastException
                                         #".*cannot be cast to .*"
                                         (merge-with second-arg {:a 1} [:a 2])))
-          :cljs    (is (p/thrown? (merge-with second-arg {:a 1} [:a 2])))
           :default (is (p/thrown? (merge-with second-arg {:a 1} [:a 2]))))
-       #?(:clj    (is (thrown-with-msg? java.lang.IllegalArgumentException
+       #?(:cljs    (is (p/thrown? (merge-with second-arg {:a 1} 1)))
+          :clj    (is (thrown-with-msg? java.lang.IllegalArgumentException
                                         #"^Don't know how to create ISeq from.*"
                                         (merge-with second-arg {:a 1} 1)))
-          :cljs    (is (p/thrown? (merge-with second-arg {:a 1} 1)))
           :default (is (p/thrown? (merge-with second-arg {:a 1} 1)))))
 
      (testing "duplicate mappings are handled according to f"

--- a/test/clojure/core_test/merge_with.cljc
+++ b/test/clojure/core_test/merge_with.cljc
@@ -10,7 +10,6 @@
    (testing "`merge-with`"
 
      (testing "zero arg behavior"
-       ;; NOTE: clojurescript differs from the rest here, bug?
        #?(:clj     (is (p/thrown? (merge-with)))
           :cljs    (is (nil? (merge-with))) ; TODO how to suppress warning
           :default (is (p/thrown? (merge-with)))))
@@ -19,7 +18,7 @@
        (is (nil? (merge-with second-arg nil)))
        (is (nil? (merge-with second-arg nil nil nil)))
        (is (= {} (merge-with second-arg {} nil)))
-       (is (= {} (merge-with second-arg nil {}))) ;; fails in basilisp => nil
+       (is (= {} (merge-with second-arg nil {})))
        (is (= {:a 1} (merge-with second-arg {:a 1} nil {})))
        (is (= {:a 1} (merge-with second-arg {:a 1} {} nil))))
 

--- a/test/clojure/core_test/merge_with.cljc
+++ b/test/clojure/core_test/merge_with.cljc
@@ -45,22 +45,12 @@
          (is (= [[10 20]] @called-with))))
 
      (testing "non-map types"
-       #?(:cljs    (is (p/thrown? (merge-with second-arg {:a 1} [:a 2])))
-          :clj     (is (thrown-with-msg? java.lang.ClassCastException
-                                         #".*cannot be cast to .*"
-                                         (merge-with second-arg {:a 1} [:a 2])))
-          :default (is (p/thrown? (merge-with second-arg {:a 1} [:a 2]))))
-       #?(:cljs    (is (p/thrown? (merge-with second-arg {:a 1} 1)))
-          :clj     (is (thrown-with-msg? java.lang.IllegalArgumentException
-                                         #"^Don't know how to create ISeq from.*"
-                                         (merge-with second-arg {:a 1} 1)))
-          :default (is (p/thrown? (merge-with second-arg {:a 1} 1)))))
+       (is (p/thrown? (merge-with second-arg {:a 1} [:a 2])))
+       (is (p/thrown? (merge-with second-arg {:a 1} 1))))
 
      (testing "duplicate mappings are handled according to f"
        (is (= {:a 2} (merge-with second-arg {:a 1} {:a 2})))
        (is (= {:a 3} (merge-with + {:a 1} {:a 2})))
-       (let [val 2]
-         (is (= {:a 4} (merge-with + {:a val} {:a val})))) ; not fooled by identity
        (is (= {:a 3 :b 1} (merge-with + {:a 1} {:b 1} nil {:a 2})))
        (is (= {:a [1 2] :b 3} (merge-with (fn [a b] (if (vector? a)
                                                       (conj a b)
@@ -74,6 +64,28 @@
          (is (= {:a 2 :b 4 :c 6} result))
          (is (sorted? result))
          (is (= [:a :b :c] (keys result)))))
+
+     (testing "key equality"
+       (is (= {3 "longbigint"}
+              (merge-with str {3 'long} {3N 'bigint})))
+       (is (= {'(0 1) "rangelist"}
+              (merge-with str {(range 2) 'range} {'(0 1) 'list})))
+       (is (= {:foo "kw", 'foo "sym"}
+              (merge-with str {:foo "kw"} {'foo "sym"})))
+       (is (= {nil "ab", false "cd", 0 "ef"}
+              (merge-with str {nil "a", false "c", 0 "e"} {nil "b", false "d", 0 "f"})))
+       #?(:cljs (is (= {0 "doublebigdecimal"}
+                       (merge-with str {0.0 'double} {0.0M 'bigdecimal})))
+          :clj  (is (= {0.0 'double, 0.0M 'bigdecimal}
+                       (merge-with str {0.0 'double} {0.0M 'bigdecimal}))))
+       #?(:cljs (is (= {0 "longdouble"}
+                       (merge-with str {0 'long} {0.0 'double})))
+          :clj  (is (= {0 'long, 0.0 'double}
+                       (merge-with str {0 'long} {0.0 'double})))))
+
+     (testing "metadata progation, when keys are equal but not identical"
+       (is (= {:meta1 true}
+              (meta (ffirst (merge-with + {^:meta1 {} 1} {^:meta2 {} 2}))))))
 
      (testing "nested maps are merged with `into`"
        (is (= {:ceo {:salary 1000000, :name "Alice"},

--- a/test/clojure/core_test/merge_with.cljc
+++ b/test/clojure/core_test/merge_with.cljc
@@ -10,8 +10,8 @@
    (testing "`merge-with`"
 
      (testing "zero arg behavior"
-       #?(:cljs    (is (nil? (merge-with)))
-          :clj     (is (p/thrown? (merge-with)))))
+       #?(:cljs (is (nil? (merge-with)))
+          :clj  (is (p/thrown? (merge-with)))))
 
      (testing "`nil`ish behavior"
        (is (nil? (merge-with second-arg nil)))
@@ -46,14 +46,14 @@
 
      (testing "non-map types"
        #?(:cljs    (is (p/thrown? (merge-with second-arg {:a 1} [:a 2])))
-          :clj    (is (thrown-with-msg? java.lang.ClassCastException
-                                        #".*cannot be cast to .*"
-                                        (merge-with second-arg {:a 1} [:a 2])))
+          :clj     (is (thrown-with-msg? java.lang.ClassCastException
+                                         #".*cannot be cast to .*"
+                                         (merge-with second-arg {:a 1} [:a 2])))
           :default (is (p/thrown? (merge-with second-arg {:a 1} [:a 2]))))
        #?(:cljs    (is (p/thrown? (merge-with second-arg {:a 1} 1)))
-          :clj    (is (thrown-with-msg? java.lang.IllegalArgumentException
-                                        #"^Don't know how to create ISeq from.*"
-                                        (merge-with second-arg {:a 1} 1)))
+          :clj     (is (thrown-with-msg? java.lang.IllegalArgumentException
+                                         #"^Don't know how to create ISeq from.*"
+                                         (merge-with second-arg {:a 1} 1)))
           :default (is (p/thrown? (merge-with second-arg {:a 1} 1)))))
 
      (testing "duplicate mappings are handled according to f"

--- a/test/clojure/core_test/merge_with.cljc
+++ b/test/clojure/core_test/merge_with.cljc
@@ -67,6 +67,14 @@
                                                       [a b]))
                                           {:a 1} {:a 2} {:b 3}))))
 
+     (testing "sorted"
+       (let [result (merge-with +
+                                (sorted-map :c 3 :a 1 :b 2)
+                                (sorted-map :b 2 :c 3 :a 1))]
+         (is (= {:a 2 :b 4 :c 6} result))
+         (is (sorted? result))
+         (is (= [:a :b :c] (keys result)))))
+
      (testing "nested maps are merged with `into`"
        (is (= {:ceo {:salary 1000000, :name "Alice"},
                :cto {:salary 500000, :name "Brenda"}}


### PR DESCRIPTION
Testing `clojure.core/merge-with`

## Manually tested with
- [x] JVM
- [x] Clojurescript
- [x] Clojure CLR
- [x] Babashka
- Basalisp (fails, see comment on nil handling)
- PHEL (I don't have access to PHP tooling at the moment)

## Dialect Differences

* Clojurescript returns a `nil` in the zero-arg case. Clojure etc throw an exception.
* Clojurescript: numeric keys have different equality semantics than the JVM.
* Basalisp returns `nil` on `(merge-with second-arg nil {})`, rest return `{}`

---

Anything else I can do to improve this? Let me know. This is a really fun way to get to know the clojure standard library!

Resolves #361 