### PR TITLE
fix(phel): restore :phel branch for p/thrown? assert-expr

### DIFF
--- a/test/clojure/core_test/portability.cljc
+++ b/test/clojure/core_test/portability.cljc
@@ -108,7 +108,30 @@
                           :actual e#})
             e#))))
 
-   :default  ; Clojure JVM, Babashka, Phel
+   :phel
+   ;; Phel's `phel.test/report` multimethod dispatches on `:type` and only
+   ;; recognises `:pass`/`:failed`/`:error` — not Clojure's `:fail`. Use
+   ;; phel-native event keys so the assertion counters update. Phel's
+   ;; throwable hierarchy is rooted at PHP's `\Throwable`; the literal is
+   ;; constructed via `symbol` because Clojure's reader treats a bare `\T`
+   ;; as a character literal (other dialects still read this file).
+   (defmethod t/assert-expr 'p/thrown?
+     [msg form]
+     (let [body (rest form)]
+       `(try
+          (let [result# (do ~@body)]
+            (t/report {:type :failed
+                       :message ~msg
+                       :expected '~form
+                       :actual result#}))
+          (catch ~(symbol "\\Throwable") e#
+            (t/report {:type :pass
+                       :message ~msg
+                       :expected '~form
+                       :actual e#})
+            e#))))
+
+   :default  ; Clojure JVM, Babashka
    (defmethod t/assert-expr 'p/thrown?
      [msg form]
      (let [body (rest form)]


### PR DESCRIPTION
## Summary

#888 assumed Phel could share the Clojure JVM `p/thrown?` body. It can't, for two reasons:

1. **Arg order.** Phel's `phel.test/assert-expr` is `[form message]`, not `[msg form]`. The `:default` body binds args wrong and `is` fails to resolve `p/thrown?` at compile time — every test file using it gets skipped. Fixed on `phel-lang` `main` ([phel-lang/phel-lang#2149](https://github.com/phel-lang/phel-lang/pull/2149)) but not yet in a stable release.

2. **Event type.** `phel.test/report` knows `:pass`/`:failed`/`:error`, not Clojure's `:fail`. `:fail` events fall through `:default` without touching counters — failed `p/thrown?` assertions are silently swallowed.

Re-add a `:phel` branch: correct arg order, catches `\Throwable`, reports `:type :failed`/`:pass`.

## Test plan

- [x] `vendor/bin/phel test test/clojure/string_test/escape.cljc` → `Passed: 6, Failed: 4, Total: 10` (previously skipped at compile time).