### PR TITLE
fix(phel): suite-compat patches for nightly run

### DIFF
--- a/test/clojure/core_test/add_watch.cljc
+++ b/test/clojure/core_test/add_watch.cljc
@@ -19,7 +19,7 @@
                                           (swap! x inc)
                                           (catch #?(:cljr clojure.lang.ExceptionInfo
                                                     :lpy basilisp.lang.exception/ExceptionInfo
-                                                    :phel Phel.Lang.ExInfoException
+                                                    :phel Phel.Lang.ExceptionInfo
                                                     :cljs :default
                                                     :clj clojure.lang.ExceptionInfo) e
                                             (let [data (ex-data e)]

--- a/test/clojure/core_test/group_by.cljc
+++ b/test/clojure/core_test/group_by.cljc
@@ -16,23 +16,25 @@
 
       )
 
-    (testing "metadata"
-      ;; Metadata shouldn't participate in the comparison
-      (let [g (group-by first [[^:foo [1] [2]] [^:bar [1] [3]]])]
-        (is (= {[1] [[[1] [2]] [[1] [3]]]} g))
-        ;; Metadata should be preserved on grouped items
-        (is (= {:foo true} (-> g (get [1]) first first meta)))
-        (is (= {:bar true} (-> g (get [1]) second first meta))))
+    #?(:phel nil ;; phel does not propagate metadata through group-by
+       :default
+       (testing "metadata"
+         ;; Metadata shouldn't participate in the comparison
+         (let [g (group-by first [[^:foo [1] [2]] [^:bar [1] [3]]])]
+           (is (= {[1] [[[1] [2]] [[1] [3]]]} g))
+           ;; Metadata should be preserved on grouped items
+           (is (= {:foo true} (-> g (get [1]) first first meta)))
+           (is (= {:bar true} (-> g (get [1]) second first meta))))
 
-      ;; Metadata should also be preserved on items and items should
-      ;; stay in the order of the initial collection
-      (let [s (group-by empty? [^:a [] ^:b [1] ^:c [] ^:d [2]])]
-        ;; validate grouping
-        (is (= s {true [[] []] false [[1] [2]]}))
-        ;; validate order of items in each grouping using attached
-        ;; metadata, which also validates that metadata is preserved
-        ;; on items
-        (is (= {:a true} (-> s (get true) first meta)))
-        (is (= {:c true} (-> s (get true) second meta)))
-        (is (= {:b true} (-> s (get false) first meta)))
-        (is (= {:d true} (-> s (get false) second meta)))))))
+         ;; Metadata should also be preserved on items and items should
+         ;; stay in the order of the initial collection
+         (let [s (group-by empty? [^:a [] ^:b [1] ^:c [] ^:d [2]])]
+           ;; validate grouping
+           (is (= s {true [[] []] false [[1] [2]]}))
+           ;; validate order of items in each grouping using attached
+           ;; metadata, which also validates that metadata is preserved
+           ;; on items
+           (is (= {:a true} (-> s (get true) first meta)))
+           (is (= {:c true} (-> s (get true) second meta)))
+           (is (= {:b true} (-> s (get false) first meta)))
+           (is (= {:d true} (-> s (get false) second meta))))))))

--- a/test/clojure/core_test/repeatedly.cljc
+++ b/test/clojure/core_test/repeatedly.cljc
@@ -22,10 +22,12 @@
 
     (testing "Single argument"
       (is (= 0 (first (repeatedly +))))
-      (testing "is lazy"
-        (let [call (repeatedly identity)]
-          (is (not (realized? call)))
-          (is (p/lazy-seq? call)))))
+      #?(:phel nil ;; phel's ConstantFolder evaluates (repeatedly identity) at compile time, calling identity with 0 args
+         :default
+         (testing "is lazy"
+           (let [call (repeatedly identity)]
+             (is (not (realized? call)))
+             (is (p/lazy-seq? call))))))
 
     (testing "Two arguments"
       (testing "is lazy"


### PR DESCRIPTION
## Summary
Three small `:phel` reader-conditional fixes so the suite stays green under [phel-lang's nightly CI](https://github.com/phel-lang/phel-lang/blob/main/.github/workflows/run-clojure-test-suite.yml). Other dialects unchanged.

### Changes
- **`add_watch.cljc`** — phel-lang renamed `Phel.Lang.ExInfoException` to `Phel.Lang.ExceptionInfo` ([phel-lang/phel-lang#2006](https://github.com/phel-lang/phel-lang/pull/2006)). Update the `:phel` branch of the catch so the test stops aborting the run mid-suite.
- **`group_by.cljc`** — phel does not propagate metadata through `group-by`. Skip the metadata testing block for `:phel` (same pattern used by other dialects with known divergences).
- **`repeatedly.cljc`** — phel's analyser-level `ConstantFolder` evaluates `(repeatedly identity)` at compile time, calling `identity` with zero args; the file fails to compile. Skip the "is lazy" single-arg subtest for `:phel` until the folder is taught not to invoke runtime-throwing calls.

### Context
The `phel-lang/clojure-test-suite` fork was carrying these patches locally, which forced ongoing divergence from upstream. After [phel-lang/clojure-test-suite#15](https://github.com/phel-lang/clojure-test-suite/pull/15) and a sync, the fork now mirrors `jank-lang/clojure-test-suite` exactly — but the Phel nightly suite job depends on these `:phel` branches to stay green.

Upstreaming them keeps the fork a pure mirror and avoids per-dialect patch drift.
