### PR TITLE
Add tests for clojure.core/identity

### DIFF
--- a/test/clojure/core_test/identity.cljc
+++ b/test/clojure/core_test/identity.cljc
@@ -30,13 +30,13 @@
         #uuid "f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
         #inst "2010-11-12T13:14:15.666-05:00"
         (atom nil)))
-  
+
     (testing "NaN"
       (is (NaN? (identity ##NaN))))
-  
+
     (testing "Meta Preservation"
       (is (true? (:foo (meta (identity ^:foo {}))))))
-  
+
     (testing "Lazy Infinite Sequence"
       (let [infinite-seq (map inc (range))]
         (is (not (realized? (identity infinite-seq))))))))

--- a/test/clojure/core_test/identity.cljc
+++ b/test/clojure/core_test/identity.cljc
@@ -1,0 +1,35 @@
+(ns clojure.core-test.identity
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.core-test.portability #?(:cljs :refer-macros :default :refer) [when-var-exists]]))
+
+; Values for tests are declared eagerly, instead of using
+; clojure.test/are. Some dialects evaluate `are` params more
+; than once, causing false negatives with object equality.
+(def test-vals
+  [nil
+   true
+   false
+   ""
+   "foo"
+   \a
+   :foo
+   :foo.bar/baz
+   'foo
+   'foo.bar/baz
+   0
+   1
+   0.1
+   -0.1
+   ##Inf
+   ##-Inf
+   []
+   (list)
+   #uuid "f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
+   #inst "2010-11-12T13:14:15.666-05:00"
+   (atom nil)])
+
+(when-var-exists identity
+  (deftest test-identity
+    (is (NaN? (identity ##NaN))) 
+    (doseq [value test-vals]
+      (is (identical? value (identity value))))))

--- a/test/clojure/core_test/identity.cljc
+++ b/test/clojure/core_test/identity.cljc
@@ -1,35 +1,42 @@
 (ns clojure.core-test.identity
-  (:require [clojure.test :refer [deftest is]]
+  (:require [clojure.test :refer [are deftest is testing]]
             [clojure.core-test.portability #?(:cljs :refer-macros :default :refer) [when-var-exists]]))
 
-; Values for tests are declared eagerly, instead of using
-; clojure.test/are. Some dialects evaluate `are` params more
-; than once, causing false negatives with object equality.
-(def test-vals
-  [nil
-   true
-   false
-   ""
-   "foo"
-   \a
-   :foo
-   :foo.bar/baz
-   'foo
-   'foo.bar/baz
-   0
-   1
-   0.1
-   -0.1
-   ##Inf
-   ##-Inf
-   []
-   (list)
-   #uuid "f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
-   #inst "2010-11-12T13:14:15.666-05:00"
-   (atom nil)])
+(defn identity-identical? [x]
+  (identical? x (identity x)))
 
 (when-var-exists identity
   (deftest test-identity
-    (is (NaN? (identity ##NaN))) 
-    (doseq [value test-vals]
-      (is (identical? value (identity value))))))
+    (testing "Basic Identities"
+      (are [x] (identity-identical? x)
+        nil
+        true
+        false
+        ""
+        "foo"
+        \a
+        :foo
+        :foo.bar/baz
+        'foo
+        'foo.bar/baz
+        0
+        1
+        0.1
+        -0.1
+        ##Inf
+        ##-Inf
+        []
+        '()
+        #uuid "f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
+        #inst "2010-11-12T13:14:15.666-05:00"
+        (atom nil)))
+  
+    (testing "NaN"
+      (is (NaN? (identity ##NaN))))
+  
+    (testing "Meta Preservation"
+      (is (true? (:foo (meta (identity ^:foo {}))))))
+  
+    (testing "Lazy Infinite Sequence"
+      (let [infinite-seq (map inc (range))]
+        (is (not (realized? (identity infinite-seq))))))))


### PR DESCRIPTION
Closes https://github.com/jank-lang/clojure-test-suite/issues/305.

### `is` vs `are`

As commented in the code, some dialects seem to evaluate `are` parameters more than once, which is problematic for object equality. Test values are declared eagerly and tested using `doseq` / `is` instead.

### ##NaN

It turns out that most dialects don't consider `##NaN` to be `=` or `identical?` to itself. This case is tested separately with `NaN?`.