### PR TITLE
Add test for clojure.core/run!

### DIFF
--- a/test/clojure/core_test/run_bang.cljc
+++ b/test/clojure/core_test/run_bang.cljc
@@ -1,0 +1,84 @@
+(ns clojure.core-test.run-bang
+  (:require [clojure.core-test.portability #?(:cljs :refer-macros :default :refer) [when-var-exists] :as p]
+            [clojure.test :refer [are deftest is testing]]))
+
+(when-var-exists run!
+
+  (defn inspect-run! [proc init coll]
+    (let [result (volatile! init)]
+      (run! (fn [v] (vswap! result proc v)) coll)
+      @result))
+
+  (deftest test-run!
+    (testing "Always Nil"
+      (are [coll] (nil? (run! identity coll))
+        []
+        [1]
+        [1 2 3]
+        ["foo" "bar"]))
+
+    (testing "Causes Side-Effects"
+      (let [calls     (volatile! 0)
+            inc-calls (fn [_] (vswap! calls inc))]
+        (run! inc-calls [])
+        (is (zero? @calls))
+
+        (run! inc-calls [0])
+        (is (= 1 @calls))
+
+        (run! inc-calls [0 0])
+        (is (= 3 @calls))))
+
+    (testing "Collection Argument"
+      (are [coll] (= 6 (inspect-run! + 0 coll))
+        [1 2 3]
+        '(1 2 3)
+        #{1 2 3})
+
+      (testing "Nil"
+        (is (zero? (inspect-run! + 0 nil))))
+
+      (testing "Strings"
+        (are [expected s] (= expected (inspect-run! conj [] s))
+          [] ""
+          [\a] "a"
+          [\f \o \o] "foo"))
+
+      ;; phel passes values to the proc (other dialects pass [k v] entries)
+      (testing "Maps"
+        (are [expected m] (= expected (inspect-run! conj #{} m))
+          #{} {}
+          #{[:foo :bar]} {:foo :bar}
+          #{[:foo :bar] [:baz :buzz]} {:foo :bar :baz :buzz}))
+
+      (testing "Non-Seqable Values"
+        (are [v] (p/thrown? (run! identity v))
+          ;; basilisp, phel, and cljs interpret chars as strings
+          #?@(:lpy [] :phel [] :cljs [] :default [\a])
+          true
+          #uuid "00000000-0000-0000-0000-000000000000"
+          1
+          1.0
+          :foo
+          'foo)))
+
+    (testing "Passes Collection Sequentially"
+      (let [coll [:foo "bar" 'baz]]
+        (is (= coll (inspect-run! conj [] coll)))))
+
+    (testing "Terminates on Exception"
+      (let [calls (volatile! 0)
+            boom! (fn [_]
+                    (vswap! calls inc)
+                    (throw (ex-info "Boom!" {})))]
+        (is (p/thrown? (run! boom! (range 2))))
+        (is (= 1 @calls))))
+
+    ;; phel implements run! in terms of doseq (other dialects use reduce)
+    (testing "Terminates on Reduced"
+      (let [calls (volatile! 0)
+            done! (fn [_]
+                    (vswap! calls inc)
+                    (reduced :done))]
+        (is (nil? (run! done! (range 2))))
+        (is (= 1 @calls))))))

--- a/test/clojure/core_test/run_bang.cljc
+++ b/test/clojure/core_test/run_bang.cljc
@@ -4,11 +4,6 @@
 
 (when-var-exists run!
 
-  (defn inspect-run! [proc init coll]
-    (let [result (volatile! init)]
-      (run! (fn [v] (vswap! result proc v)) coll)
-      @result))
-
   (deftest test-run!
     (testing "Always Nil"
       (are [coll] (nil? (run! identity coll))
@@ -20,6 +15,9 @@
     (testing "Causes Side-Effects"
       (let [calls     (volatile! 0)
             inc-calls (fn [_] (vswap! calls inc))]
+        (run! inc-calls nil)
+        (is (zero? @calls))
+
         (run! inc-calls [])
         (is (zero? @calls))
 
@@ -29,42 +27,19 @@
         (run! inc-calls [0 0])
         (is (= 3 @calls))))
 
-    (testing "Collection Argument"
-      (are [coll] (= 6 (inspect-run! + 0 coll))
-        [1 2 3]
-        '(1 2 3)
-        #{1 2 3})
-
-      (testing "Nil"
-        (is (zero? (inspect-run! + 0 nil))))
-
-      (testing "Strings"
-        (are [expected s] (= expected (inspect-run! conj [] s))
-          [] ""
-          [\a] "a"
-          [\f \o \o] "foo"))
-
-      ;; phel passes values to the proc (other dialects pass [k v] entries)
-      (testing "Maps"
-        (are [expected m] (= expected (inspect-run! conj #{} m))
-          #{} {}
-          #{[:foo :bar]} {:foo :bar}
-          #{[:foo :bar] [:baz :buzz]} {:foo :bar :baz :buzz}))
-
-      (testing "Non-Seqable Values"
-        (are [v] (p/thrown? (run! identity v))
-          ;; basilisp, phel, and cljs interpret chars as strings
-          #?@(:lpy [] :phel [] :cljs [] :default [\a])
-          true
-          #uuid "00000000-0000-0000-0000-000000000000"
-          1
-          1.0
-          :foo
-          'foo)))
+    (testing "Seqable is Required"
+      (let [sum  (volatile! 0)
+            add! (fn [n] (vswap! sum + n))]
+        (is (p/thrown? (run! add! true)))
+        (is (zero? @sum))
+        (run! add! #{1 2 3})
+        (is (= 6 @sum))))
 
     (testing "Passes Collection Sequentially"
-      (let [coll [:foo "bar" 'baz]]
-        (is (= coll (inspect-run! conj [] coll)))))
+      (let [result (volatile! [])
+            coll   [:foo "bar" 'baz]]
+        (run! (fn [v] (vswap! result conj v)) coll)
+        (is (= coll @result))))
 
     (testing "Terminates on Exception"
       (let [calls (volatile! 0)
@@ -74,7 +49,6 @@
         (is (p/thrown? (run! boom! (range 2))))
         (is (= 1 @calls))))
 
-    ;; phel implements run! in terms of doseq (other dialects use reduce)
     (testing "Terminates on Reduced"
       (let [calls (volatile! 0)
             done! (fn [_]


### PR DESCRIPTION
This PR closes https://github.com/jank-lang/clojure-test-suite/issues/470.

Passes on Babashka, JVM, CLR, CLJS, and Basilisp.

### Phel

Three tests fail on Phel:
- _Collection Arguments > Maps_ (2 cases)
- _Terminates on Reduced_

The _Maps_ failures seem to be a real gap between Phel and the other dialects.

I would like some guidance on the _Terminates on Reduced_ test. This basically asserts that `run!` is implemented in terms of `reduce`, which the docstring claims:

> Runs the supplied procedure (via reduce), for purposes of side
> effects, on successive items in the collection. Returns nil

However, I wonder if this is documented more as an implementation detail rather than a contract.