### PR TITLE
Add tests for clojure.core/list

### DIFF
--- a/test/clojure/core_test/list.cljc
+++ b/test/clojure/core_test/list.cljc
@@ -1,0 +1,63 @@
+(ns clojure.core-test.list
+  (:require [clojure.core-test.portability #?(:cljs :refer-macros :default :refer) [when-var-exists]]
+            [clojure.test :refer [are deftest is testing]]))
+
+(when-var-exists list
+  (deftest test-list
+    (testing "satisfies list?"
+      (are [v] (list? v)
+        (list)
+        (list 1)
+        (list 1 2)
+        (list 1 2 3)))
+
+    (testing "empty list"
+      (is (= '() (list))))
+
+    (testing "single element"
+      (are [expected v] (= expected (list v))
+        '(1) 1
+        '(:a) :a
+        '("string") "string"
+        '(nil) nil
+        '(\a) \a
+        '(true) true
+        '(false) false))
+
+    (testing "multiple elements"
+      (are [expected actual] (= expected actual)
+        '(1 2 3) (list 1 2 3)
+        '(:a :b :c) (list :a :b :c)
+        '("zz" "a" "42") (list "zz" "a" "42")))
+
+    (testing "multiple data structures"
+      (are [expected actual] (= expected actual)
+        '([1 2] [3 4]) (list [1 2] [3 4])
+        '((1 2) (3 4)) (list '(1 2) '(3 4))
+        '({:a 1} {:b 2}) (list {:a 1} {:b 2})
+        '(#{1 2} #{3 4}) (list #{1 2} #{3 4})
+        '([]) (list [])
+        '(()) (list '())
+        '({}) (list {})
+        '(#{}) (list #{})))
+
+    (testing "preserves duplicates"
+      (are [expected actual] (= expected actual)
+        '(1 1 1) (list 1 1 1)
+        '(:a :a) (list :a :a)
+        '(nil nil nil) (list nil nil nil)))
+
+    (testing "large lists"
+      (let [result (apply list (range 100))]
+        (is (= (range 100) result))
+        (is (list? result))))
+
+    (testing "different types together"
+      (are [expected actual] (= expected actual)
+        '(1 2.5 3N 4M) (list 1 2.5 3N 4M)
+        '(1 :a "b" \c true nil () [] #{} {}) (list 1 :a "b" \c true nil '() [] #{} {})))
+
+    (testing "variadic args"
+      (are [expected actual] (= expected actual)
+        '(1 2 3 4 5 6 7 8 9 10) (list 1 2 3 4 5 6 7 8 9 10)
+        '(1 2 3 4 5 6 nil) (list 1 2 3 4 5 6 nil)))))


### PR DESCRIPTION
This PR closes https://github.com/jank-lang/clojure-test-suite/issues/336.

These tests were heavily inspired by its `vector` counterpart: https://github.com/jank-lang/clojure-test-suite/blob/main/test/clojure/core_test/vector.cljc.

### Differences from `vector` Tests
- Preference for `are` over repeated `is`
- Dedicated _satisfies list?_ section over a `list?` checks in various tests
- One extra `(list '())` test
- Removal of `into` operation from _large lists_
  - `(= (range 100) coll)` (should) works with either vectors or lists
  - Test is no longer dependent on `into` working properly (or at all)

### Aligning `vector` and `list` tests

I think it would be valuable to align the structure of these two tests. I can make those changes in this PR, or create a follow-up PR that aligns the two.