### PR TITLE
Update `clojure.core-test.take-nth` to use doall

### DIFF
--- a/test/clojure/core_test/take_nth.cljc
+++ b/test/clojure/core_test/take_nth.cljc
@@ -35,6 +35,9 @@
         (range 0 10 1) -1 (range 10)
         (range 0 10 2) -2 (range 10))
 
+      ;; Note: `doall` is a portable way to coax out the exception for
+      ;; 'lazy-seq'. Sequences that don't implement 'IDrop' will only throw
+      ;; after accessing the second element.
       (is (p/thrown? (doall (take-nth nil (range 10)))))
       (is (p/thrown? (transduce (take-nth nil) conj [] (range 10))))
       #?(:cljs

--- a/test/clojure/core_test/take_nth.cljc
+++ b/test/clojure/core_test/take_nth.cljc
@@ -35,7 +35,7 @@
         (range 0 10 1) -1 (range 10)
         (range 0 10 2) -2 (range 10))
 
-      (is (p/thrown? (seq (take-nth nil (range 10)))))
+      (is (p/thrown? (doall (take-nth nil (range 10)))))
       (is (p/thrown? (transduce (take-nth nil) conj [] (range 10))))
       #?(:cljs
          (is (= [] (transduce (take-nth 0) conj [] (range 10))))


### PR DESCRIPTION
So the exception that is being caused by this test is indirectly testing that a Clojure dialect supports `IDrop`:

- [`clojure.lang.IDrop - Clojure`](https://github.com/clojure/clojure/blob/clojure-1.12.2/src/clj/clojure/core.clj#L2946)
- [`cljs.core/IDrop - ClojureScript`](https://github.com/clojure/clojurescript/blob/v1.12/src/main/cljs/cljs/core.cljs#L4897)
- [`clojure.lang.IDrop - ClojureCLR`](https://github.com/clojure/clojure-clr/blob/clojure-1.12.2/Clojure/Clojure.Source/clojure/core.clj#L2946)

Since jank doesn't implement such an optimization, this test was failing because getting the first element doesn't result in calling `pos?`. However getting any element after would cause the same exception in jank. You get the exact same behavior in `clojure` if the collection does not implement `IDrop`:

```clojure
% clj
Clojure 1.12.2
user=> (do (seq (take-nth nil (range 10))) :foo) ;; clojure.lang.LongRange implements IDrop
Execution error (NullPointerException) at user/eval1 (REPL:1).
Cannot invoke "Object.getClass()" because "x" is null
user=> (do (seq (take-nth nil (list 0 1))) :foo) ;; clojure.lang.PersistentList does not
:foo
user=> 
```

I think using `doall` allows us to ignore this minor implementation detail.