### PR TITLE
Add :lg reader-conditional branches for map-order-dependent tests (cons, cycle, mapcat)

### DIFF
--- a/test/clojure/core_test/cons.cljc
+++ b/test/clojure/core_test/cons.cljc
@@ -14,12 +14,13 @@
                             #?@(:lpy [] :default [1 (sorted-set 1 2 3) [1 1 2 3]])
                             ;; This works in Basilisp but order is not consistent, so
                             ;; another test below handles the potential ordering issues.
-                            #?@(:lpy [] :default [1 {:2 2 :3 3} [1 [:2 2] [:3 3]]])
+                            #?@(:lpy [] :lg [] :default [1 {:2 2 :3 3} [1 [:2 2] [:3 3]]])
                             [0 1] '(2 3) [[0 1] 2 3])
 
       ;; This is a duplicate of a test above intended to address inconsistent iteration
       ;; order for map types.
-      #?(:lpy (is (contains? #{[1 [:2 2] [:3 3]] [1 [:3 3] [:2 2]]} (cons 1 {:2 2 :3 3})))))
+      #?(:lpy (is (contains? #{[1 [:2 2] [:3 3]] [1 [:3 3] [:2 2]]} (cons 1 {:2 2 :3 3})))
+         :lg (is (contains? #{[1 [:2 2] [:3 3]] [1 [:3 3] [:2 2]]} (cons 1 {:2 2 :3 3})))))
 
     (testing "infinite seqs"
       (is (= -1 (first (cons -1 (range))))))

--- a/test/clojure/core_test/cycle.cljc
+++ b/test/clojure/core_test/cycle.cljc
@@ -21,6 +21,9 @@
       #?(:lpy (is (contains? #{[[:a 1] [:b 2] [:a 1]]
                                [[:b 2] [:a 1] [:b 2]]}
                              (vec (take 3 (cycle {:a 1 :b 2})))))
+         :lg (is (contains? #{[[:a 1] [:b 2] [:a 1]]
+                              [[:b 2] [:a 1] [:b 2]]}
+                            (vec (take 3 (cycle {:a 1 :b 2})))))
          :default (is (= [[:a 1] [:b 2] [:a 1]] (take 3 (cycle {:a 1 :b 2}))))))
 
     (testing "bad shape"

--- a/test/clojure/core_test/mapcat.cljc
+++ b/test/clojure/core_test/mapcat.cljc
@@ -30,6 +30,7 @@
       (is (= [\h \i] (mapcat identity ["hi"]))))
     (testing "flatten key/value pairs"
       #?(:lpy (is (contains? #{[:a 1 :b 2] [:b 2 :a 1]} (vec (mapcat identity {:a 1 :b 2}))))
+         :lg (is (contains? #{[:a 1 :b 2] [:b 2 :a 1]} (vec (mapcat identity {:a 1 :b 2}))))
          :default (is (= [:a 1 :b 2 :c 3] (mapcat identity {:a 1 :b 2 :c 3})))))
     (testing "function returns nil"
       (is (= [] (mapcat (constantly nil) [1 2 3]))))


### PR DESCRIPTION
## What

Adds `:lg` (let-go) reader-conditional branches to three tests that currently assume a specific iteration order for small map literals — `cons.cljc`, `cycle.cljc`, and `mapcat.cljc` — mirroring the existing `:lpy` (Basilisp) branches on the same assertions.

let-go's persistent maps are unordered (like Basilisp's, and like Clojure maps in general once they promote past `array-map` size). Clojure documents no ordering guarantee for maps, and these three tests already acknowledge that by giving Basilisp order-agnostic variants (`contains? #{...}` over the admissible orderings). This PR extends the same branches to `:lg`:

- `cons.cljc`: skip the order-dependent map row in the table test; take the existing order-agnostic duplicate
- `cycle.cljc`: order-agnostic `(take 3 (cycle {:a 1 :b 2}))`
- `mapcat.cljc`: order-agnostic `(mapcat identity {:a 1 :b 2})` (two-entry map, both orderings admissible)

No `:default` behavior changes; JVM Clojure/ClojureScript/jank branches are untouched.

## Context

let-go (https://github.com/nooga/let-go) runs this suite as its conformance gate (currently 5656 passing). These three tests are the only order-dependent failures for an unordered-map implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
