### PR TITLE
Improve `rest` tests

### DIFF
--- a/test/clojure/core_test/rest.cljc
+++ b/test/clojure/core_test/rest.cljc
@@ -1,13 +1,31 @@
 (ns clojure.core-test.rest
-  (:require [clojure.test :as t :refer [deftest is]]
-            [clojure.core-test.portability #?(:cljs :refer-macros :default :refer) [when-var-exists]]))
+  (:require [clojure.test :as t :refer [deftest is are]]
+            [clojure.core-test.portability :as p #?(:cljs :refer-macros :default :refer) [when-var-exists]]))
 
 (when-var-exists rest
   (deftest test-rest
-    (is (= '(1 2 3 4 5 6 7 8 9) (rest (range 0 10))))
-    (is (= '(2 3 4 5 6 7 8 9) (rest (rest (range 0 10)))))
-    (is (= 1 (first (rest (range)))))
-    (is (= '(2 3) (rest [1 2 3])))
-    (is (= '() (rest nil)))
-    (is (= '() (rest '())))
-    (is (= '() (rest [])))))
+    (are [expected xs] (= expected (rest xs))
+      '(1 2 3 4 5 6 7 8 9) (range 0 10)
+      '(2 3 4 5 6 7 8 9) (rest (range 0 10)) ; do it twice
+      '(2 3) [1 2 3]
+      '(\e \l \l \o) "hello"
+      '(1 2 3 4) (int-array (range 5))
+      '([:b 2] [:c 3]) (sorted-map :a 1 :b 2 :c 3)
+      '(:b :c) (sorted-set :a :b :c)
+      '() [1]
+      '() '(1)
+      '() {:a 1}
+      '() #{:a}
+      '() (rest "a")
+      '() nil
+      '() '()
+      '() []
+      '() "")
+    
+    (is (= 1 (first (rest (range)))))   ; infinite lazy seq
+    (is (= 2 (count (rest {:a 1 :b 2 :c 3})))) ; don't know order
+    (is (= 2 (count (rest #{:a :b :c})))) ; don't know order
+
+    ;; non-seqable values throw
+    (is (p/thrown? (rest 1)))
+    (is (p/thrown? (rest :a)))))


### PR DESCRIPTION
Added test cases and migrated cases to use `are`.