### PR TITLE
Update Basilisp portability macro to use `assert-expr`

### DIFF
--- a/test/clojure/core_test/portability.cljc
+++ b/test/clojure/core_test/portability.cljc
@@ -58,15 +58,15 @@
 #?(:cljs nil   ; CLJS is special. See below.
 
    :lpy
-   (defmethod t/gen-assert 'p/thrown?
-     [form msg _line-num]
+   (defmethod t/assert-expr 'p/thrown?
+     [form msg]
      (let [body (rest form)]
        `(try
           (let [result# (do ~@body)]
-            (vswap! t/*test-failures* conj {:type :failure
-                                            :message ~msg
-                                            :expected '~form
-                                            :actual result#}))
+            (t/do-report {:type :fail
+                          :message ~msg
+                          :expected '~form
+                          :actual result#}))
           (catch ~'Exception e#
             ;; don't do anything on success
             e#))))


### PR DESCRIPTION
I merged updates to `basilisp.test` to support `assert-expr` and `do-report` in https://github.com/basilisp-lang/basilisp/pull/1345 so I wanted to update the portability macro here to use those now instead of the older non-standard utilities.