### PR TITLE
Add let-go Unicode scalar char expectation

### DIFF
--- a/test/clojure/core_test/char.cljc
+++ b/test/clojure/core_test/char.cljc
@@ -17,7 +17,10 @@
        (is (= \ষ (char 2487))))
      (testing "4+ byte characters throw"
        (is #?(:jank    (= (first "𐅦") (char 65895))
-              ;; this seems to be an off by one error
+              ;; 65895 is U+10167 ("𐅧"). Runtimes with Unicode-scalar
+              ;; characters can represent it directly; JVM Clojure's char is
+              ;; a UTF-16 code unit and rejects values above U+FFFF.
+              :lg      (= (first "𐅧") (char 65895))
               :lpy     (= (first "𐅧") (char 65895))
               :cljs    (= \ŧ (char 65895))
               :default (p/thrown? (char 65895))))))


### PR DESCRIPTION
Summary:
- add an :lg reader branch for char 65895 as Unicode scalar U+10167
- clarify Unicode-scalar behavior versus JVM UTF-16 char behavior
- preserve all existing dialect expectations

Validation:
- nooga/let-go char fixture: 9 passed, 0 failed, 0 errors

This lets let-go consume the shared fixture without a local skip while retaining its broad Unicode character support.